### PR TITLE
Fix build errors and add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Node.js
+node_modules/
+**/node_modules/
+
+# Build output
+/dist/
+**/dist/
+
+# Env files
+.env
+*.env
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Others
+.DS_Store

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,8 @@
     "class-validator": "^0.14.0",
     "class-transformer": "^0.5.1",
     "prisma": "^5.10.2",
-    "@prisma/client": "^5.10.2"
+    "@prisma/client": "^5.10.2",
+    "@nestjs/swagger": "^7.0.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -2,7 +2,6 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
-import * as fs from 'fs';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);

--- a/backend/src/payments/payments.service.ts
+++ b/backend/src/payments/payments.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreatePaymentDto } from './dto/create-payment.dto';
-import { Prisma } from '@prisma/client';
+import { Prisma, Decimal } from '@prisma/client';
 
 @Injectable()
 export class PaymentsService {
@@ -10,7 +10,7 @@ export class PaymentsService {
   async create(data: CreatePaymentDto) {
     const tx = await this.prisma.transaction.create({
       data: {
-        amount: new Prisma.Decimal(data.amount.value),
+        amount: new Decimal(data.amount.value),
         currency: data.amount.currency,
         status: 'PENDING',
         customer_email: data.customer.email,


### PR DESCRIPTION
## Summary
- add `@nestjs/swagger` dependency
- correct `Decimal` import in PaymentsService
- remove unused `fs` import
- ignore node modules and build artifacts

## Testing
- `npm run build` *(fails: nest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862da342f98832fbbca3f84fcc6756a