### PR TITLE
Fix Prisma Decimal usage

### DIFF
--- a/backend/src/payments/payments.service.ts
+++ b/backend/src/payments/payments.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreatePaymentDto } from './dto/create-payment.dto';
-import { Prisma, Decimal } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 
 @Injectable()
 export class PaymentsService {
@@ -10,7 +10,7 @@ export class PaymentsService {
   async create(data: CreatePaymentDto) {
     const tx = await this.prisma.transaction.create({
       data: {
-        amount: new Decimal(data.amount.value),
+        amount: new Prisma.Decimal(data.amount.value),
         currency: data.amount.currency,
         status: 'PENDING',
         customer_email: data.customer.email,


### PR DESCRIPTION
## Summary
- update payments service imports
- use `Prisma.Decimal` when creating payment amounts

## Testing
- `npx nest build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/nest)*

------
https://chatgpt.com/codex/tasks/task_e_6862e97c3a64832f864d791b4fa8edb4