### PR TITLE
Add initial Prisma migration and automate DB setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ This repository contains a minimal demo of a Pay‑In flow with a NestJS backend
 
 ## Local start
 
+Before running the services for the first time apply the Prisma migrations:
+
+```bash
+cd backend
+npx prisma migrate dev
+cd ..
+```
+
+Then start all containers:
+
 ```bash
 docker-compose up -d
 ```

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,5 +8,6 @@ RUN npm run build
 FROM node:20-alpine
 WORKDIR /app
 COPY --from=build /app .
+RUN npx prisma generate
 ENV NODE_ENV=production
-CMD ["node", "dist/main.js"]
+CMD ["sh", "-c", "npx prisma migrate deploy && node dist/main.js"]

--- a/backend/prisma/migrations/20240630202000_init/migration.sql
+++ b/backend/prisma/migrations/20240630202000_init/migration.sql
@@ -1,0 +1,20 @@
+-- CreateExtension
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- CreateTable
+CREATE TABLE "Transaction" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "amount" DECIMAL(65,30) NOT NULL,
+    "currency" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "customer_email" TEXT NOT NULL,
+    CONSTRAINT "Transaction_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "IdempotencyKey" (
+    "key" TEXT NOT NULL,
+    "response_json" JSON NOT NULL,
+    CONSTRAINT "IdempotencyKey_pkey" PRIMARY KEY ("key")
+);

--- a/backend/prisma/migrations/migration_lock.toml
+++ b/backend/prisma/migrations/migration_lock.toml
@@ -1,0 +1,1 @@
+provider = "postgresql"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - postgres
     ports:
       - "3000:3000"
+    command: sh -c "npx prisma migrate deploy && node dist/main.js"
   frontend:
     build: ./frontend
     environment:


### PR DESCRIPTION
## Summary
- create first Prisma migration
- run `prisma generate` during backend image build
- apply migrations on container start
- document migration steps

## Testing
- `npm run build` *(fails: nest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f10d84b8832f98a052bf29ad89fb