### PR TITLE
Fix docker contexts

### DIFF
--- a/adapter-kora/Dockerfile
+++ b/adapter-kora/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim
 WORKDIR /app
-COPY ./app /app/app
-COPY ../wait-for-it.sh /wait-for-it.sh
+COPY adapter-kora/app /app/app
+COPY wait-for-it.sh /wait-for-it.sh
 RUN pip install fastapi uvicorn[standard] requests
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/core-payments/Dockerfile
+++ b/core-payments/Dockerfile
@@ -1,9 +1,9 @@
 FROM python:3.12-slim
 WORKDIR /app
-COPY ../common /app/common
-COPY ./app /app/app
-COPY ../alembic /app/alembic
-COPY ../alembic.ini /app/alembic.ini
-COPY ../wait-for-it.sh /wait-for-it.sh
+COPY common /app/common
+COPY core-payments/app /app/app
+COPY alembic /app/alembic
+COPY alembic.ini /app/alembic.ini
+COPY wait-for-it.sh /wait-for-it.sh
 RUN pip install fastapi uvicorn[standard] sqlmodel psycopg2-binary pika requests alembic
 CMD ["/wait-for-it.sh", "db:5432", "sh", "-c", "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,9 @@ services:
       - "15672:15672"
 
   gateway-api:
-    build: ./gateway-api
+    build:
+      context: .
+      dockerfile: gateway-api/Dockerfile
     depends_on:
       db:
         condition: service_healthy
@@ -31,7 +33,9 @@ services:
       - "8000:8000"
 
   core-payments:
-    build: ./core-payments
+    build:
+      context: .
+      dockerfile: core-payments/Dockerfile
     depends_on:
       db:
         condition: service_healthy
@@ -43,7 +47,9 @@ services:
       ADAPTER_URL: http://adapter-kora:8000
 
   adapter-kora:
-    build: ./adapter-kora
+    build:
+      context: .
+      dockerfile: adapter-kora/Dockerfile
     environment:
       WEBHOOK_URL: http://webhook-dispatcher:8000/webhooks/kora
     depends_on:
@@ -51,13 +57,17 @@ services:
         condition: service_started
 
   ledger:
-    build: ./ledger
+    build:
+      context: .
+      dockerfile: ledger/Dockerfile
     depends_on:
       db:
         condition: service_healthy
 
   webhook-dispatcher:
-    build: ./webhook-dispatcher
+    build:
+      context: .
+      dockerfile: webhook-dispatcher/Dockerfile
     depends_on:
       rabbitmq:
         condition: service_started

--- a/gateway-api/Dockerfile
+++ b/gateway-api/Dockerfile
@@ -1,9 +1,9 @@
 FROM python:3.12-slim
 WORKDIR /app
-COPY ../common /app/common
-COPY ./app /app/app
-COPY ../alembic /app/alembic
-COPY ../alembic.ini /app/alembic.ini
-COPY ../wait-for-it.sh /wait-for-it.sh
+COPY common /app/common
+COPY gateway-api/app /app/app
+COPY alembic /app/alembic
+COPY alembic.ini /app/alembic.ini
+COPY wait-for-it.sh /wait-for-it.sh
 RUN pip install fastapi==0.111.0 uvicorn[standard] sqlmodel psycopg2-binary pika alembic
 CMD ["/wait-for-it.sh", "db:5432", "sh", "-c", "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000"]

--- a/ledger/Dockerfile
+++ b/ledger/Dockerfile
@@ -1,9 +1,9 @@
 FROM python:3.12-slim
 WORKDIR /app
-COPY ../common /app/common
-COPY ./app /app/app
-COPY ../alembic /app/alembic
-COPY ../alembic.ini /app/alembic.ini
-COPY ../wait-for-it.sh /wait-for-it.sh
+COPY common /app/common
+COPY ledger/app /app/app
+COPY alembic /app/alembic
+COPY alembic.ini /app/alembic.ini
+COPY wait-for-it.sh /wait-for-it.sh
 RUN pip install fastapi uvicorn[standard] sqlmodel psycopg2-binary alembic
 CMD ["/wait-for-it.sh", "db:5432", "sh", "-c", "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000"]

--- a/webhook-dispatcher/Dockerfile
+++ b/webhook-dispatcher/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim
 WORKDIR /app
-COPY ./app /app/app
-COPY ../wait-for-it.sh /wait-for-it.sh
+COPY webhook-dispatcher/app /app/app
+COPY wait-for-it.sh /wait-for-it.sh
 RUN pip install fastapi uvicorn[standard] pika
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- set root context for python service builds
- copy files from root within each Dockerfile

## Testing
- `docker compose build` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686455b8796c832faceff50b0fd325cd