### PR TITLE
Fix missing router dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,8 @@
     "@emotion/styled": "^11.11.0",
     "framer-motion": "^10.12.16",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "react-router-dom": "^6"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",


### PR DESCRIPTION
## Summary
- add `react-router-dom` to frontend dependencies

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68645a24b020832fa4cdb70629f5e059