### PR TITLE
Fix queue declaration for gateway consumer

### DIFF
--- a/gateway-api/app/main.py
+++ b/gateway-api/app/main.py
@@ -70,6 +70,7 @@ def consume():
                     tx.status = PaymentStatus.SUCCEEDED
                     s.add(tx)
                     s.commit()
+    channel.queue_declare(queue='gateway', durable=True)
     channel.basic_consume(queue='gateway', on_message_callback=cb, auto_ack=True)
     channel.queue_bind(queue='gateway', exchange='payments.events', routing_key='payment.succeeded')
     channel.start_consuming()


### PR DESCRIPTION
## Summary
- ensure `gateway` queue exists before consuming

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `bash -x scripts/smoke.sh` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686468744ad4832f97f2cabe6c268620